### PR TITLE
Support for updating a CoreData attribute named "sortIndex" in case an (optional) argument 'context' is passed (preferably the viewContext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This package contains a generic **ReoderableForEach** component, which can then 
 * Works with any SwiftUI layout.
 * Binding to dynamically enable/disable reordering functionality.
 * Custom item rendering with additional info on if the current item is being dragged or not.
+* Support for updating a CoreData attribute named "sortIndex" in case an (optional) argument 'context' is passed (preferably the viewContext)
 
 ## Installation
 

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -6,23 +6,28 @@ where Data : Hashable, Content : View {
     
     
     
-    // TODO: accept a NSManagedObjectContext 
+    // TODO: optionally accept a NSManagedObjectContext
     
     @Binding var data: [Data]
     
     
     
     @Binding var allowReordering: Bool
+    
+    let context: NSManagedObjectContext? // MARK: new, wip, optional
+
     private let content: (Data, Bool) -> Content
     
     @State private var draggedItem: Data?
     @State private var hasChangedLocation: Bool = false
     
-    public init(_ data: Binding<[Data]>,
-                allowReordering: Binding<Bool>,
-                @ViewBuilder content: @escaping (Data, Bool) -> Content) {
+    
+    public init (_ data: Binding<[Data]>, allowReordering: Binding<Bool>, context: NSManagedObjectContext? = nil, @ViewBuilder content: @escaping (Data, Bool) -> Content) {
         _data = data
         _allowReordering = allowReordering
+        
+        self.context = context // MARK: new, wip, optional
+        
         self.content = content
     }
     
@@ -68,7 +73,18 @@ where Data : Hashable, Content : View {
                     data.move(fromOffsets: IndexSet(integer: from),
                               toOffset: (to > from) ? to + 1 : to)
                 }
+                
+                print("dropEntered() - items: \(data.count)")
+                print("dropEntered() - item : \(draggedItem)")
+                print("dropEntered() - from : \(from)")
+                print("dropEntered() - to   : \(to)\n")
+                
+                // TODO: move CoreData indices
+
+                // TODO: save CoreData context
+                
             }
+            
         }
         
         func dropUpdated(info: DropInfo) -> DropProposal? {
@@ -82,6 +98,8 @@ where Data : Hashable, Content : View {
         }
     }
 }
+
+// MARK: tests
 
 struct ReorderingVStackTest: View {
     @State private var data = ["Apple", "Orange", "Banana", "Lemon", "Tangerine"]

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -6,7 +6,7 @@ where Data : Hashable, Content : View {
     
     
     
-    // TODO: fix "Cannot convert value of type 'Binding<FetchRequest<Preset>.Configuration>' to expected argument type 'Binding<[Data]>'" in calling view
+    // TODO: accept a NSManagedObjectContext 
     
     @Binding var data: [Data]
     

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -80,6 +80,9 @@ where Data : Hashable, Content : View {
                 // MARK: we have a context, so update CoreData items and, finally, context!
                 
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                    
+                    // TODO: need to check whether all items have a sortIndex, not sure where to do this yet, but important WIP
+                    
                     print("dropEntered() - items      : \(data.count)")
                     print("dropEntered() - draggedItem: \(draggedItem.value(forKey: "title"))")
                     print("dropEntered() - item       : \(item.value(forKey: "title"))")
@@ -88,9 +91,29 @@ where Data : Hashable, Content : View {
                     
                     // TODO: update CoreData sortIndex
                     
-                    // TODO: move CoreData indices
+                    print("dropEntered() - draggedItem.sortIndex -> \(draggedItem.value(forKey: "sortIndex"))")
+                    print("dropEntered() - item.sortIndex -> \(item.value(forKey: "sortIndex"))")
+
+                    draggedItem.setValue(to, forKey: "sortIndex")
+                    item.setValue(from, forKey: "sortIndex")
+                    
+                    print("dropEntered() - changed sortIndexes")
+                    print("dropEntered() - draggedItem.sortIndex -> \(draggedItem.value(forKey: "sortIndex"))")
+                    print("dropEntered() - item.sortIndex -> \(item.value(forKey: "sortIndex"))\n")
                     
                     // TODO: save CoreData context
+                    
+                    if context.hasChanges {
+                        do {
+                            try context.save()
+                            
+                            print("dropEntered() - saved context")
+                        } catch {
+                            print("dropEntered() - context save error")
+                        }
+                    } else {
+                        print("dropEntered() - context has no changes, skipping save")
+                    }
                 }
                 
                 //

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -3,138 +3,138 @@ import UniformTypeIdentifiers
 
 public struct ReorderableForEach<Data, Content>: View
 where Data : Hashable, Content : View {
-  @Binding var data: [Data]
-  @Binding var allowReordering: Bool
-  private let content: (Data, Bool) -> Content
-  
-  @State private var draggedItem: Data?
-  @State private var hasChangedLocation: Bool = false
-  
-  public init(_ data: Binding<[Data]>,
-              allowReordering: Binding<Bool>,
-              @ViewBuilder content: @escaping (Data, Bool) -> Content) {
-    _data = data
-    _allowReordering = allowReordering
-    self.content = content
-  }
-  
-  public var body: some View {
-    ForEach(data, id: \.self) { item in
-      if allowReordering {
-        content(item, hasChangedLocation && draggedItem == item)
-          .onDrag {
-            draggedItem = item
-            return NSItemProvider(object: "\(item.hashValue)" as NSString)
-          }
-          .onDrop(of: [UTType.plainText], delegate: DragRelocateDelegate(
-            item: item,
-            data: $data,
-            draggedItem: $draggedItem,
-            hasChangedLocation: $hasChangedLocation))
-      } else {
-        content(item, false)
-      }
-    }
-  }
-  
-  struct DragRelocateDelegate<Data>: DropDelegate
-  where Data : Equatable {
-    let item: Data
     @Binding var data: [Data]
-    @Binding var draggedItem: Data?
-    @Binding var hasChangedLocation: Bool
+    @Binding var allowReordering: Bool
+    private let content: (Data, Bool) -> Content
     
-    func dropEntered(info: DropInfo) {
-      guard item != draggedItem,
-            let current = draggedItem,
-            let from = data.firstIndex(of: current),
-            let to = data.firstIndex(of: item)
-      else {
-        return
-      }
-      
-      hasChangedLocation = true
-      
-      if data[to] != current {
-        withAnimation {
-          data.move(fromOffsets: IndexSet(integer: from),
-                    toOffset: (to > from) ? to + 1 : to)
+    @State private var draggedItem: Data?
+    @State private var hasChangedLocation: Bool = false
+    
+    public init(_ data: Binding<[Data]>,
+                allowReordering: Binding<Bool>,
+                @ViewBuilder content: @escaping (Data, Bool) -> Content) {
+        _data = data
+        _allowReordering = allowReordering
+        self.content = content
+    }
+    
+    public var body: some View {
+        ForEach(data, id: \.self) { item in
+            if allowReordering {
+                content(item, hasChangedLocation && draggedItem == item)
+                    .onDrag {
+                        draggedItem = item
+                        return NSItemProvider(object: "\(item.hashValue)" as NSString)
+                    }
+                    .onDrop(of: [UTType.plainText], delegate: DragRelocateDelegate(
+                        item: item,
+                        data: $data,
+                        draggedItem: $draggedItem,
+                        hasChangedLocation: $hasChangedLocation))
+            } else {
+                content(item, false)
+            }
         }
-      }
     }
     
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-      DropProposal(operation: .move)
+    struct DragRelocateDelegate<Data>: DropDelegate
+    where Data : Equatable {
+        let item: Data
+        @Binding var data: [Data]
+        @Binding var draggedItem: Data?
+        @Binding var hasChangedLocation: Bool
+        
+        func dropEntered(info: DropInfo) {
+            guard item != draggedItem,
+                  let current = draggedItem,
+                  let from = data.firstIndex(of: current),
+                  let to = data.firstIndex(of: item)
+            else {
+                return
+            }
+            
+            hasChangedLocation = true
+            
+            if data[to] != current {
+                withAnimation {
+                    data.move(fromOffsets: IndexSet(integer: from),
+                              toOffset: (to > from) ? to + 1 : to)
+                }
+            }
+        }
+        
+        func dropUpdated(info: DropInfo) -> DropProposal? {
+            DropProposal(operation: .move)
+        }
+        
+        func performDrop(info: DropInfo) -> Bool {
+            hasChangedLocation = false
+            draggedItem = nil
+            return true
+        }
     }
-    
-    func performDrop(info: DropInfo) -> Bool {
-      hasChangedLocation = false
-      draggedItem = nil
-      return true
-    }
-  }
 }
 
 struct ReorderingVStackTest: View {
-  @State private var data = ["Apple", "Orange", "Banana", "Lemon", "Tangerine"]
-  @State private var allowReordering = false
-  
-  var body: some View {
-    VStack {
-      Toggle("Allow reordering", isOn: $allowReordering)
-        .frame(width: 200)
-        .padding(.bottom, 30)
-      VStack {
-        ReorderableForEach($data, allowReordering: $allowReordering) { item, isDragged in
-          Text(item)
-            .font(.title)
-            .padding()
-            .frame(minWidth: 200, minHeight: 50)
-            .border(Color.blue)
-            .background(Color.red.opacity(0.9))
-            .overlay(isDragged ? Color.white.opacity(0.6) : Color.clear)
+    @State private var data = ["Apple", "Orange", "Banana", "Lemon", "Tangerine"]
+    @State private var allowReordering = false
+    
+    var body: some View {
+        VStack {
+            Toggle("Allow reordering", isOn: $allowReordering)
+                .frame(width: 200)
+                .padding(.bottom, 30)
+            VStack {
+                ReorderableForEach($data, allowReordering: $allowReordering) { item, isDragged in
+                    Text(item)
+                        .font(.title)
+                        .padding()
+                        .frame(minWidth: 200, minHeight: 50)
+                        .border(Color.blue)
+                        .background(Color.red.opacity(0.9))
+                        .overlay(isDragged ? Color.white.opacity(0.6) : Color.clear)
+                }
+            }
         }
-      }
     }
-  }
 }
 
 struct ReorderingVGridTest: View {
-  @State private var data = ["Apple", "Orange", "Banana", "Lemon", "Tangerine"]
-  @State private var allowReordering = false
-  
-  var body: some View {
-    VStack {
-      Toggle("Allow reordering", isOn: $allowReordering)
-        .frame(width: 200)
-        .padding(.bottom, 30)
-      LazyVGrid(columns: [
-        GridItem(.flexible()),
-        GridItem(.flexible())
-      ]) {
-        ReorderableForEach($data, allowReordering: $allowReordering) { item, isDragged in
-          Text(item)
-            .font(.title)
-            .padding()
-            .frame(minWidth: 150, minHeight: 50)
-            .border(Color.blue)
-            .background(Color.red.opacity(0.9))
-            .overlay(isDragged ? Color.white.opacity(0.6) : Color.clear)
+    @State private var data = ["Apple", "Orange", "Banana", "Lemon", "Tangerine"]
+    @State private var allowReordering = false
+    
+    var body: some View {
+        VStack {
+            Toggle("Allow reordering", isOn: $allowReordering)
+                .frame(width: 200)
+                .padding(.bottom, 30)
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ]) {
+                ReorderableForEach($data, allowReordering: $allowReordering) { item, isDragged in
+                    Text(item)
+                        .font(.title)
+                        .padding()
+                        .frame(minWidth: 150, minHeight: 50)
+                        .border(Color.blue)
+                        .background(Color.red.opacity(0.9))
+                        .overlay(isDragged ? Color.white.opacity(0.6) : Color.clear)
+                }
+            }
         }
-      }
+        .padding()
     }
-    .padding()
-  }
 }
 
 struct ReorderingVStackTest_Previews: PreviewProvider {
-  static var previews: some View {
-    ReorderingVStackTest()
-  }
+    static var previews: some View {
+        ReorderingVStackTest()
+    }
 }
 
 struct ReorderingGridTest_Previews: PreviewProvider {
-  static var previews: some View {
-    ReorderingVGridTest()
-  }
+    static var previews: some View {
+        ReorderingVGridTest()
+    }
 }

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -40,7 +40,11 @@ where Data : Hashable, Content : View {
                         return NSItemProvider(object: "\(item.hashValue)" as NSString)
                     }
                     .onDrop(of: [UTType.plainText], delegate: DragRelocateDelegate(
+                        
                         item: item,
+                        
+                        context: context, // MARK: new, optional
+                        
                         data: $data,
                         draggedItem: $draggedItem,
                         hasChangedLocation: $hasChangedLocation))
@@ -53,6 +57,8 @@ where Data : Hashable, Content : View {
     struct DragRelocateDelegate<Data>: DropDelegate
     where Data : Equatable {
         let item: Data
+        let context: NSManagedObjectContext? // MARK: new, wip, optional
+
         @Binding var data: [Data]
         @Binding var draggedItem: Data?
         @Binding var hasChangedLocation: Bool
@@ -74,16 +80,26 @@ where Data : Hashable, Content : View {
                               toOffset: (to > from) ? to + 1 : to)
                 }
                 
-                print("dropEntered() - items: \(data.count)")
-                print("dropEntered() - item : \(draggedItem)")
-                print("dropEntered() - from : \(from)")
-                print("dropEntered() - to   : \(to)\n")
                 
-                // TODO: update CoreData sortIndex
                 
-                // TODO: move CoreData indices
-
-                // TODO: save CoreData context
+                // MARK: we have a context, so update CoreData items and, finally, context!
+                
+                if let context = context {
+                    print("dropEntered() - items: \(data.count)")
+                    print("dropEntered() - item : \(draggedItem)")
+                    print("dropEntered() - from : \(from)")
+                    print("dropEntered() - to   : \(to)\n")
+                    
+                    // TODO: update CoreData sortIndex
+                    
+                    // TODO: move CoreData indices
+                    
+                    // TODO: save CoreData context
+                }
+                
+                //
+                
+                
                 
             }
             

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -62,8 +62,17 @@ where Data : Hashable, Content : View {
             hasChangedLocation = true
             
             if data[to] != current {
+                // handle UI indices
+                withAnimation {
+                    data.move(fromOffsets: IndexSet(integer: from),
+                              toOffset: (to > from) ? to + 1 : to)
+                }
+                
                 // support for CoreData
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                    
+                    // TODO: fast movements can cause CD indices to get mixed up, use UI indices instead
+                    
                     // handle CD indices
                     let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
                     let itemIndex = item.value(forKey: "sortIndex")
@@ -76,12 +85,6 @@ where Data : Hashable, Content : View {
                         do { try context.save() }
                         catch { }
                     }
-                }
-                
-                // handle UI indices
-                withAnimation {
-                    data.move(fromOffsets: IndexSet(integer: from),
-                              toOffset: (to > from) ? to + 1 : to)
                 }
             }
         }

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -6,8 +6,8 @@ where Data : Hashable, Content : View {
     @Binding var data: [Data]
     @Binding var allowReordering: Bool
     
-    let context: NSManagedObjectContext? // optional, passing a context enables CoreData support
-
+    let context: NSManagedObjectContext? // optional, passing context enables CoreData support, requires an attribute 'sortIndex' in  CD model
+    
     private let content: (Data, Bool) -> Content
     
     @State private var draggedItem: Data?
@@ -64,14 +64,10 @@ where Data : Hashable, Content : View {
             if data[to] != current {
                 // support for CoreData
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
-                    // swap indices
-                    
+                    // handle CD indices
                     let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
                     let itemIndex = item.value(forKey: "sortIndex")
 
-//                    draggedItem.setValue(to, forKey: "sortIndex")
-//                    item.setValue(from, forKey: "sortIndex")
-                    
                     draggedItem.setValue(itemIndex, forKey: "sortIndex")
                     item.setValue(draggedItemIndex, forKey: "sortIndex")
    
@@ -82,7 +78,7 @@ where Data : Hashable, Content : View {
                     }
                 }
                 
-                // handle indices
+                // handle UI indices
                 withAnimation {
                     data.move(fromOffsets: IndexSet(integer: from),
                               toOffset: (to > from) ? to + 1 : to)

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -3,7 +3,15 @@ import UniformTypeIdentifiers
 
 public struct ReorderableForEach<Data, Content>: View
 where Data : Hashable, Content : View {
+    
+    
+    
+    // TODO: fix "Cannot convert value of type 'Binding<FetchRequest<Preset>.Configuration>' to expected argument type 'Binding<[Data]>'" in calling view
+    
     @Binding var data: [Data]
+    
+    
+    
     @Binding var allowReordering: Bool
     private let content: (Data, Bool) -> Content
     

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -65,8 +65,15 @@ where Data : Hashable, Content : View {
                 // support for CoreData
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
                     // swap indices
-                    draggedItem.setValue(to, forKey: "sortIndex")
-                    item.setValue(from, forKey: "sortIndex")
+                    
+                    let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
+                    let itemIndex = item.value(forKey: "sortIndex")
+
+//                    draggedItem.setValue(to, forKey: "sortIndex")
+//                    item.setValue(from, forKey: "sortIndex")
+                    
+                    draggedItem.setValue(itemIndex, forKey: "sortIndex")
+                    item.setValue(draggedItemIndex, forKey: "sortIndex")
    
                     // save context
                     if context.hasChanges {

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -69,7 +69,8 @@ where Data : Hashable, Content : View {
                 }
                 
                 // support for CoreData
-                if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+//                if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                if let context = context, let data = data as? [NSManagedObject]  {
                                         
                     // handle CD indices
                     
@@ -83,7 +84,7 @@ where Data : Hashable, Content : View {
 //                    item.setValue(draggedItemIndex, forKey: "sortIndex")
                     
                     // MARK: new code
-                    if let data = data as? [NSManagedObject] {
+//                    if let data = data as? [NSManagedObject] {
                         var index = 0
                         
                         for preset in data {
@@ -91,7 +92,7 @@ where Data : Hashable, Content : View {
                             
                             index += 1
                         }
-                    }
+//                    }
    
                     // save context
                     if context.hasChanges {

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -70,15 +70,28 @@ where Data : Hashable, Content : View {
                 
                 // support for CoreData
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                                        
+                    // handle CD indices
                     
                     // TODO: fast movements can cause CD indices to get mixed up, use UI indices instead
-                    
-                    // handle CD indices
-                    let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
-                    let itemIndex = item.value(forKey: "sortIndex")
 
-                    draggedItem.setValue(itemIndex, forKey: "sortIndex")
-                    item.setValue(draggedItemIndex, forKey: "sortIndex")
+                    // MARK: old code
+//                    let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
+//                    let itemIndex = item.value(forKey: "sortIndex")
+//
+//                    draggedItem.setValue(itemIndex, forKey: "sortIndex")
+//                    item.setValue(draggedItemIndex, forKey: "sortIndex")
+                    
+                    // MARK: new code
+                    if let data = data as? [NSManagedObject] {
+                        var index = 0
+                        
+                        for preset in data {
+                            preset.setValue(index, forKey: "sortIndex")
+                            
+                            index += 1
+                        }
+                    }
    
                     // save context
                     if context.hasChanges {

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -75,20 +75,16 @@ where Data : Hashable, Content : View {
             hasChangedLocation = true
             
             if data[to] != current {
-                withAnimation {
-                    data.move(fromOffsets: IndexSet(integer: from),
-                              toOffset: (to > from) ? to + 1 : to)
-                }
-                
                 
                 
                 // MARK: we have a context, so update CoreData items and, finally, context!
                 
-                if let context = context {
-                    print("dropEntered() - items: \(data.count)")
-                    print("dropEntered() - item : \(draggedItem)")
-                    print("dropEntered() - from : \(from)")
-                    print("dropEntered() - to   : \(to)\n")
+                if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                    print("dropEntered() - items      : \(data.count)")
+                    print("dropEntered() - draggedItem: \(draggedItem.value(forKey: "title"))")
+                    print("dropEntered() - item       : \(item.value(forKey: "title"))")
+                    print("dropEntered() - from       : \(from)")
+                    print("dropEntered() - to         : \(to)\n")
                     
                     // TODO: update CoreData sortIndex
                     
@@ -98,6 +94,19 @@ where Data : Hashable, Content : View {
                 }
                 
                 //
+                
+                
+                
+                // MARK: now update records themselves
+                
+                withAnimation {
+                    data.move(fromOffsets: IndexSet(integer: from),
+                              toOffset: (to > from) ? to + 1 : to)
+                }
+                
+                
+                
+
                 
                 
                 

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -3,31 +3,21 @@ import UniformTypeIdentifiers
 
 public struct ReorderableForEach<Data, Content>: View
 where Data : Hashable, Content : View {
-    
-    
-    
-    // TODO: optionally accept a NSManagedObjectContext
-    
     @Binding var data: [Data]
-    
-    
-    
     @Binding var allowReordering: Bool
     
-    let context: NSManagedObjectContext? // MARK: new, wip, optional
+    let context: NSManagedObjectContext? // MARK: WIP
 
     private let content: (Data, Bool) -> Content
     
     @State private var draggedItem: Data?
     @State private var hasChangedLocation: Bool = false
     
-    
     public init (_ data: Binding<[Data]>, allowReordering: Binding<Bool>, context: NSManagedObjectContext? = nil, @ViewBuilder content: @escaping (Data, Bool) -> Content) {
         _data = data
         _allowReordering = allowReordering
         
-        self.context = context // MARK: new, wip, optional
-        
+        self.context = context // MARK: WIP
         self.content = content
     }
     
@@ -40,11 +30,8 @@ where Data : Hashable, Content : View {
                         return NSItemProvider(object: "\(item.hashValue)" as NSString)
                     }
                     .onDrop(of: [UTType.plainText], delegate: DragRelocateDelegate(
-                        
                         item: item,
-                        
-                        context: context, // MARK: new, optional
-                        
+                        context: context, // MARK: WIP
                         data: $data,
                         draggedItem: $draggedItem,
                         hasChangedLocation: $hasChangedLocation))
@@ -57,7 +44,7 @@ where Data : Hashable, Content : View {
     struct DragRelocateDelegate<Data>: DropDelegate
     where Data : Equatable {
         let item: Data
-        let context: NSManagedObjectContext? // MARK: new, wip, optional
+        let context: NSManagedObjectContext? // MARK: WIP
 
         @Binding var data: [Data]
         @Binding var draggedItem: Data?
@@ -75,21 +62,14 @@ where Data : Hashable, Content : View {
             hasChangedLocation = true
             
             if data[to] != current {
-                
-                
-                // MARK: we have a context, so update CoreData items and, finally, context!
-                
+                // in case we got a CoreData context in our arguments, persist indexing
                 if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
-                    
-                    // TODO: need to check whether all items have a sortIndex, not sure where to do this yet, but important WIP
-                    
+                    // handle indices
                     print("dropEntered() - items      : \(data.count)")
                     print("dropEntered() - draggedItem: \(draggedItem.value(forKey: "title"))")
                     print("dropEntered() - item       : \(item.value(forKey: "title"))")
                     print("dropEntered() - from       : \(from)")
                     print("dropEntered() - to         : \(to)\n")
-                    
-                    // TODO: update CoreData sortIndex
                     
                     print("dropEntered() - draggedItem.sortIndex -> \(draggedItem.value(forKey: "sortIndex"))")
                     print("dropEntered() - item.sortIndex -> \(item.value(forKey: "sortIndex"))")
@@ -100,14 +80,11 @@ where Data : Hashable, Content : View {
                     print("dropEntered() - changed sortIndexes")
                     print("dropEntered() - draggedItem.sortIndex -> \(draggedItem.value(forKey: "sortIndex"))")
                     print("dropEntered() - item.sortIndex -> \(item.value(forKey: "sortIndex"))\n")
-                    
-                    // TODO: save CoreData context
-                    
+                                    
+                    // persist through context save (if needed)
                     if context.hasChanges {
                         do {
                             try context.save()
-                            
-                            print("dropEntered() - saved context")
                         } catch {
                             print("dropEntered() - context save error")
                         }
@@ -116,25 +93,12 @@ where Data : Hashable, Content : View {
                     }
                 }
                 
-                //
-                
-                
-                
-                // MARK: now update records themselves
-                
+                // handle UI indices
                 withAnimation {
                     data.move(fromOffsets: IndexSet(integer: from),
                               toOffset: (to > from) ? to + 1 : to)
                 }
-                
-                
-                
-
-                
-                
-                
             }
-            
         }
         
         func dropUpdated(info: DropInfo) -> DropProposal? {

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -79,6 +79,8 @@ where Data : Hashable, Content : View {
                 print("dropEntered() - from : \(from)")
                 print("dropEntered() - to   : \(to)\n")
                 
+                // TODO: update CoreData sortIndex
+                
                 // TODO: move CoreData indices
 
                 // TODO: save CoreData context

--- a/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
+++ b/Sources/SwiftUIReorderableForEach/SwiftUIReorderableForEach.swift
@@ -68,33 +68,15 @@ where Data : Hashable, Content : View {
                               toOffset: (to > from) ? to + 1 : to)
                 }
                 
-                // support for CoreData
-//                if let context = context, let draggedItem = draggedItem as? NSManagedObject, let item = item as? NSManagedObject {
+                // support for CoreData (rewrite all sortIndex' in order of UI appearance)
                 if let context = context, let data = data as? [NSManagedObject]  {
-                                        
-                    // handle CD indices
-                    
-                    // TODO: fast movements can cause CD indices to get mixed up, use UI indices instead
-
-                    // MARK: old code
-//                    let draggedItemIndex = draggedItem.value(forKey: "sortIndex")
-//                    let itemIndex = item.value(forKey: "sortIndex")
-//
-//                    draggedItem.setValue(itemIndex, forKey: "sortIndex")
-//                    item.setValue(draggedItemIndex, forKey: "sortIndex")
-                    
-                    // MARK: new code
-//                    if let data = data as? [NSManagedObject] {
                         var index = 0
                         
                         for preset in data {
                             preset.setValue(index, forKey: "sortIndex")
-                            
                             index += 1
                         }
-//                    }
    
-                    // save context
                     if context.hasChanges {
                         do { try context.save() }
                         catch { }


### PR DESCRIPTION
These sortIndex'es are updated to resemble the order they appear in view after reordering.

Addresses issue #2 with the limitation that we can not act on FetchedResultsdirectly, but on a [NSManagedObject].

